### PR TITLE
error on Prestashop Informations Back Office Menu

### DIFF
--- a/themeinstallator.php
+++ b/themeinstallator.php
@@ -69,8 +69,8 @@ class ThemeInstallator extends Module
 
 	public function __construct()
 	{
-		@set_time_limit(0);
-		@ini_set('memory_limit', '2G');
+		@set_time_limit();
+		@ini_get('memory_limit');
 
 		$this->name = 'themeinstallator';
 		$this->version = '2.8.3';


### PR DESCRIPTION
Hello,

If we put values here and if you go to the 

backoffice/parameters/informations you will see memory limit at 2G and set_time_limit at 0.

And when you have memory problems you don't understand why :))
Marius